### PR TITLE
brothers and sisters call can handle one level product variants now

### DIFF
--- a/lib/akeneo/product_service.rb
+++ b/lib/akeneo/product_service.rb
@@ -62,7 +62,8 @@ module Akeneo
     end
 
     def load_parents(family, akeneo_parent, akeneo_grand_parent)
-      return [] if akeneo_parent.nil? || akeneo_grand_parent.nil?
+      return [] if akeneo_parent.nil?
+      return [akeneo_parent] if akeneo_grand_parent.nil?
 
       @product_model_service.all(with_family: family).select do |parent|
         parent['parent'] == akeneo_grand_parent['code']

--- a/spec/akeneo/product_service_spec.rb
+++ b/spec/akeneo/product_service_spec.rb
@@ -103,9 +103,31 @@ describe Akeneo::ProductService do
           'parent' => nil
         }
       end
+      let(:sister_product) do
+        {
+          'identifier' => 'sister_product_id',
+          'family' => 'family_code',
+          'parent' => 'a_parent_code'
+        }
+      end
+      let(:product_from_same_family_with_different_parent) do
+        {
+          'identifier' => 404,
+          'family' => 'family_code',
+          'parent' => 'different_parent_code'
+        }
+      end
+      let(:all_products_from_family) do
+        [
+          product,
+          sister_product,
+          product_from_same_family_with_different_parent
+        ]
+      end
 
       before do
         allow(product_model_service).to receive(:find).and_return(parent)
+        allow(service).to receive(:all) { all_products_from_family }
       end
 
       it 'requests the akeneo parent' do
@@ -114,9 +136,15 @@ describe Akeneo::ProductService do
         expect(product_model_service).to have_received(:find).with(parent_code)
       end
 
-      it 'returns only the product, is this right @schnika?' do
+      it 'requests all products with the parent family' do
+        service.brothers_and_sisters(product_id)
+
+        expect(service).to have_received(:all).with(with_family: 'family_code')
+      end
+
+      it 'returns the product with the sisters product' do
         actual = service.brothers_and_sisters(product_id)
-        expected = [product]
+        expected = [product, sister_product]
 
         expect(actual).to eql(expected)
       end


### PR DESCRIPTION
The brothers and sisters call could not handle product models with one axis.

Setup:
product_model 1
 -> product_1234
 -> product_5678
 -> product_9011
 
Before:
`akeneo_service.brothers_and_sisters(1234)`
`=> [product_1234]`

After:
`akeneo_service.brothers_and_sisters(1234)`
`=> [product_1234, product_5678, product_9011]`