### PR TITLE
Fixes #9 handle whitespace characters in url path

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akeneo (1.7.0)
+    akeneo (1.7.1)
       httparty (~> 0.17.0)
       mime-types
       redis
@@ -33,7 +33,7 @@ GEM
     public_suffix (3.0.3)
     rainbow (3.0.0)
     rake (12.3.2)
-    redis (4.1.1)
+    redis (4.1.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akeneo (1.7.1)
+    akeneo (1.7.0)
       httparty (~> 0.17.0)
       mime-types
       redis

--- a/akeneo.gemspec
+++ b/akeneo.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'akeneo'
-  spec.version       = '1.7.0'
+  spec.version       = '1.7.1'
   spec.authors       = ['AWN Dev Team']
   spec.email         = ['edv@awn.de']
 

--- a/akeneo.gemspec
+++ b/akeneo.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'akeneo'
-  spec.version       = '1.7.1'
+  spec.version       = '1.7.0'
   spec.authors       = ['AWN Dev Team']
   spec.email         = ['edv@awn.de']
 

--- a/lib/akeneo/api.rb
+++ b/lib/akeneo/api.rb
@@ -19,8 +19,8 @@ module Akeneo
       authorization_service.fresh_access_token
     end
 
-    def product(sku)
-      product_service.find(sku)
+    def product(code)
+      product_service.find(code)
     end
 
     def products(with_family: nil, with_completeness: nil, updated_after: nil)
@@ -78,8 +78,8 @@ module Akeneo
       product_model_service.find(product_parent['parent'])
     end
 
-    def family(family_code)
-      family_service.find(family_code)
+    def family(code)
+      family_service.find(code)
     end
 
     def family_variant(family_code, family_variant_code)
@@ -90,14 +90,11 @@ module Akeneo
       family_variant = family_service.variant(family_code, family_variant_code)
       return [] unless family_variant
 
-      [
-        find_attribute_code_for_level(family_variant, 1),
-        find_attribute_code_for_level(family_variant, 2)
-      ].compact
+      [find_attribute_code_for_level(family_variant, 1), find_attribute_code_for_level(family_variant, 2)].compact
     end
 
-    def brothers_and_sisters(id)
-      product_service.brothers_and_sisters(id)
+    def brothers_and_sisters(code)
+      product_service.brothers_and_sisters(code)
     end
 
     def attribute(code)

--- a/lib/akeneo/service_base.rb
+++ b/lib/akeneo/service_base.rb
@@ -9,6 +9,7 @@ module Akeneo
   class ServiceBase
     prepend Cache
 
+    API_VERSION = 'v1'
     DEFAULT_PAGINATION_TYPE = :search_after
     DEFAULT_PAGINATION_LIMIT = 100
 
@@ -55,21 +56,21 @@ module Akeneo
 
     def get_request(path, options = {})
       HTTParty.get(
-        "#{@url}/api/rest/v1#{path}",
+        build_url(path),
         options.merge(headers: default_request_headers)
       )
     end
 
     def patch_request(path, options = {})
       HTTParty.patch(
-        "#{@url}/api/rest/v1#{path}",
+        build_url(path),
         options.merge(headers: default_request_headers)
       )
     end
 
     def patch_for_collection_request(path, options = {})
       HTTParty.patch(
-        "#{@url}/api/rest/v1#{path}",
+        build_url(path),
         options.merge(headers: collection_request_headers)
       )
     end
@@ -92,7 +93,17 @@ module Akeneo
       return unless response.success?
 
       url = response.parsed_response.dig('_links', 'next', 'href')
-      url.to_s.split('/api/rest/v1').last
+      url.to_s.split("/api/rest/#{API_VERSION}").last
+    end
+
+    def build_url(path)
+      "#{@url}/api/rest/#{API_VERSION}#{escape_path(path)}"
+    end
+
+    def escape_path(path)
+      return if path.nil?
+
+      path.to_s.gsub(' ', '%20')
     end
   end
 end

--- a/spec/akeneo/service_base_spec.rb
+++ b/spec/akeneo/service_base_spec.rb
@@ -6,6 +6,47 @@ describe Akeneo::ServiceBase do
   let(:url) { 'http://akeneo.api' }
   let(:access_token) { 'access_token' }
 
+  class AkeneoTestService < described_class
+    def find(code)
+      get_request("/test_path/#{code}")
+    end
+  end
+
+  describe '#get_request' do
+    let(:service) do
+      AkeneoTestService.new(url: 'url', access_token: 'token')
+    end
+
+    let(:expected_http_headers) do
+      {
+        'Authorization' => 'Bearer token',
+        'Content-Type' => 'application/json'
+      }
+    end
+
+    before do
+      allow(HTTParty).to receive(:get)
+    end
+
+    it 'perfoms a http get request' do
+      service.find('a_code')
+
+      expect(HTTParty).to have_received(:get).with(
+        'url/api/rest/v1/test_path/a_code',
+        headers: expected_http_headers
+      )
+    end
+
+    it 'escapes the provided path' do
+      service.find('a code')
+
+      expect(HTTParty).to have_received(:get).with(
+        'url/api/rest/v1/test_path/a%20code',
+        headers: expected_http_headers
+      )
+    end
+  end
+
   describe 'mixins' do
     it 'prepends the Cache module before the ServiceBase' do
       service_base_index = described_class.ancestors.index { |a| a == described_class }


### PR DESCRIPTION
By replacing the whitespace with a '%20' in the url path
akeneo is able to process requests for resources that have a
whitespace in their code. 'e.g.' `/product_models/an akeneo product
model`